### PR TITLE
Fix incorrect epoch being used in case of falsy values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export const decode = (
     sunflake: bigint | number | string,
     config?: EpochConfig
 ) => {
-    const epoch = BigInt(config?.epoch || DEFAULT_EPOCH);
+    const epoch = BigInt(config?.epoch ?? DEFAULT_EPOCH);
     let snowflake = BigInt(sunflake);
     const seq = snowflake & BigInt(4095);
 


### PR DESCRIPTION
In the decode function if the epoch value is falsy such as `0` it will be set as the default epoch. This contradicts the generate function which allows for falsy values causing incorrect decodes in case the epoch was set to 0. 